### PR TITLE
prevent git from prompting for credentials

### DIFF
--- a/prefetch-github.go
+++ b/prefetch-github.go
@@ -80,6 +80,8 @@ func main() {
 		"--rev",
 		revArg,
 	)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 
 	output, execErr := cmd.CombinedOutput()
 


### PR DESCRIPTION
prevents invalid repositories from erroring out correctly.